### PR TITLE
Use ansible_distribution_release to install Docker

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -14,7 +14,7 @@
 
     - name: Add Docker Repository
       apt_repository:
-        repo: deb https://download.docker.com/linux/ubuntu bionic stable
+        repo: deb https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
         state: present
 
     - name: Update apt and install docker-ce


### PR DESCRIPTION
Fixes #163.

Use the `ansible_distribution_release` variable to install Docker CE.

- [x] ~Add / update the documentation~
