### PR TITLE
Unify hosts format along the doc

### DIFF
--- a/docs/install/ansible.rst
+++ b/docs/install/ansible.rst
@@ -75,10 +75,10 @@ Create a ``hosts`` file with the following content:
 
 .. code-block:: text
 
-    [servers]
+    [server]
     51.178.95.237
 
-    [servers:vars]
+    [server:vars]
     ansible_python_interpreter=/usr/bin/python3
 
 Replace the IP corresponds to your server. If you already defined the hostname (see :ref:`install/https`),
@@ -86,10 +86,26 @@ you can also specify the domain name:
 
 .. code-block:: text
 
-    [servers]
+    [server]
     dev.plasmabio.org
 
-    [servers:vars]
+    [server:vars]
+    ansible_python_interpreter=/usr/bin/python3
+
+If you have multiple servers, the ``hosts`` file will look like the following:
+
+.. code-block:: text
+
+    [server1]
+    51.178.95.237 
+
+    [server2]
+    51.178.95.238
+
+    [server1:vars]
+    ansible_python_interpreter=/usr/bin/python3
+
+    [server2:vars]
     ansible_python_interpreter=/usr/bin/python3
 
 Then run the following command after replacing ``<user>`` by your user on the remote machine:
@@ -227,6 +243,7 @@ Ansible will log the progress in the terminal, and will indicate which component
 
 .. _install/individual-playbook:
 
+
 Running individual playbooks
 ----------------------------
 
@@ -242,6 +259,7 @@ and update The Littlest JupyterHub):
 For more in-depth details about the Ansible playbook, check out the
 `official documentation <https://docs.ansible.com/ansible/latest/user_guide/playbooks.html>`_.
 
+
 Using a specific version of Plasma
 ----------------------------------
 
@@ -253,13 +271,13 @@ This is specified in the ``ansible/vars/default.yml`` file:
 
     tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
 
-
 But it is also possible to use a specific git commit hash, branch or tag. For example to use the version of Plasma
 tagged as ``v0.1``:
 
 .. code-block:: yaml
 
     tljh_plasma: git+https://github.com/plasmabio/plasma@v0.1#"egg=tljh-plasma&subdirectory=tljh-plasma"
+
 
 List of available playbooks
 ---------------------------
@@ -270,8 +288,19 @@ The Ansible playbooks are located in the ``ansible/`` directory:
 - ``utils.yml``: install extra system packages useful for debugging and system administration
 - ``users.yml``: create the tests users on the host
 - ``quotas.yml``: enable quotas on the host to limit disk usage
+- ``include-groups.yml``: add user groups to JupyterHub
 - ``cockpit.yml``: install Cockpit on the host as a monitoring tool
 - ``tljh.yml``: install TLJH and the Plasma TLJH plugin
 - ``https.yml``: enable HTTPS for TLJH
 - ``uninstall.yml``: uninstall TLJH only
 - ``site.yml``: the main playbook that references some of the other playbooks
+
+
+Running playbook on a given server
+----------------------------------
+
+If you have multiple servers defined in the ``hosts`` file, you can run a playbook on a single server with the ``--limit`` option:
+
+.. code-block:: bash
+
+    ansible-playbook site.yml -i hosts -u ubuntu --limit server1

--- a/docs/install/https.rst
+++ b/docs/install/https.rst
@@ -15,28 +15,39 @@ Enable HTTPS
 ------------
 
 Support for HTTPS is handled automatically thanks to `Let's Encrypt <https://letsencrypt.org>`_, which also
-handles the renewal of the certificates when they are about to expire.
+handles the automatic renewal of the certificates when they are about to expire.
 
-In your ``hosts`` file, add the ``name_server`` and ``letsencrypt_email`` variables on the same line as the server IP:
+In your ``hosts`` file, add the ``name_server`` and ``letsencrypt_email`` variables:
 
 .. code-block:: text
 
-    [servers]
-    51.178.95.237 name_server=dev.plasmabio.org letsencrypt_email=contact@plasmabio.org
+    [server]
+    51.178.95.237
 
-    [servers:vars]
+    [server:vars]
     ansible_python_interpreter=/usr/bin/python3
+    name_server=dev.plasmabio.org
+    letsencrypt_email=contact@plasmabio.org
 
 If you have multiple servers, the ``hosts`` file will look like the following:
 
 .. code-block:: text
 
-    [servers]
-    51.178.95.237 name_server=dev1.plasmabio.org letsencrypt_email=contact@plasmabio.org
-    51.178.95.238 name_server=dev2.plasmabio.org letsencrypt_email=contact@plasmabio.org
+    [server1]
+    51.178.95.237 
 
-    [servers:vars]
+    [server2]
+    51.178.95.238
+
+    [server1:vars]
     ansible_python_interpreter=/usr/bin/python3
+    name_server=dev1.plasmabio.org
+    letsencrypt_email=contact@plasmabio.org
+
+    [server2:vars]
+    ansible_python_interpreter=/usr/bin/python3
+    name_server=dev2.plasmabio.org
+    letsencrypt_email=contact@plasmabio.org
 
 Modify these values to the ones you want to use.
 


### PR DESCRIPTION
- [x] Add / update the documentation

Fix #175 

Documentation [Deploying with Ansible](https://docs.plasmabio.org/en/latest/install/ansible.html) is also modified:

- The case of multiple servers is addressed.
- The command line to use a single server from a multiple server `hosts` file is  provided:
    ```
    ansible-playbook site.yml -i hosts -u ubuntu --limit server1
    ```

