### PR TITLE
Match user home dir in container with system

### DIFF
--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -63,6 +63,7 @@ class PlasmaSpawner(SpawnerMixin, SystemUserSpawner):
         # the escaped environment name is used to create a new folder in the user home directory
         home = os.path.abspath(os.path.join(user_home, os.path.pardir))
         self.host_homedir_format_string = f"{home}/{username}"
+        self.image_homedir_format_string = f"{home}/{username}"
         # pass the image name to the Docker container
         self.environment = {"USER_IMAGE": display_name}
 


### PR DESCRIPTION
Fix #181 

Tested with success on a VM. Within an environment, user is in `/path/to/home/user/env-name` that matches the real path on the system.

@jtpio thank you for your guidance. Could please do an extra check since the Docker configuration is crucial in Plasma?


