### PR TITLE
Update to the new `repo2docker` image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+conda:
+  environment: docs/requirements.txt
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,8 @@
 version: 2
 
-conda:
-  environment: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt
 
 sphinx:
   builder: html

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -44,8 +44,8 @@
       shell: "tljh-config reload hub"
 
     # Pull the repo2docker image to build user images
-    - name: Pull jupyter/repo2docker
+    - name: Pull the repo2docker Docker image
       docker_image:
-        name: jupyter/repo2docker
-        tag: master
+        name: quay.io/jupyterhub/repo2docker
+        tag: main
         source: pull

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
 git+https://github.com/plasmabio/tljh-repo2docker
+jupyterhub~=1.5
 notebook
 pytest
 pytest-aiohttp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,10 +52,8 @@ if os.path.exists(os.path.join(here, '_static')):
 # and seems to be hard to control.
 html_sidebars = {
     '**': [
-        # 'about.html',
         'globaltoc.html',
         'relations.html',
         'searchbox.html',
-        # 'donate.html',
     ]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,6 @@ html_sidebars = {
         'globaltoc.html',
         'relations.html',
         'searchbox.html',
-        'donate.html',
+        # 'donate.html',
     ]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ if os.path.exists(os.path.join(here, '_static')):
 # and seems to be hard to control.
 html_sidebars = {
     '**': [
-        'about.html',
+        # 'about.html',
         'globaltoc.html',
         'relations.html',
         'searchbox.html',

--- a/docs/contributing/local.rst
+++ b/docs/contributing/local.rst
@@ -48,7 +48,7 @@ User environments are built with ``repo2docker`` running in a Docker container. 
 
 .. code-block:: bash
 
-  docker pull jupyter/repo2docker:master
+  docker pull quay.io/jupyterhub/repo2docker:main
 
 Create a config file for the group list
 ---------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Based on the Jupyter ecosystem, Plasma allows the creation and the management of
 with an easy deployement on bare-metal servers or virtual machines.
 
 Plasma utilizes `tljh-repo2docker <https://github.com/plasmabio/tljh-repo2docker>`_, 
-a `repo2docker <https://github.com/jupyter/repo2docker>`_ plugin for `The Littlest JupyterHub <https://tljh.jupyter.org/en/latest/>`_.
+a `repo2docker <https://github.com/jupyterhub/repo2docker>`_ plugin for `The Littlest JupyterHub <https://tljh.jupyter.org/en/latest/>`_.
 
 For more details, have a look at:
 

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner", "tljh_repo2docker"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker"],
 )

--- a/tljh-plasma/tljh_plasma/permissions.py
+++ b/tljh-plasma/tljh_plasma/permissions.py
@@ -3,6 +3,7 @@ import json
 
 from itertools import groupby
 
+from inspect import isawaitable
 from jupyterhub.apihandlers import APIHandler
 from jupyterhub.handlers.base import BaseHandler
 from jupyterhub.orm import Base, Column, Integer, Unicode
@@ -12,7 +13,7 @@ from tornado.web import authenticated
 
 
 def list_groups(include_groups):
-    """ Get the list of available groups """
+    """Get the list of available groups"""
     return [g.gr_name for g in grp.getgrall() if g.gr_name in include_groups]
 
 
@@ -48,7 +49,10 @@ class PermissionsHandler(BaseHandler):
             groups=all_groups,
             permissions=mapping,
         )
-        self.write(html)
+        if isawaitable(html):
+            self.write(await html)
+        else:
+            self.write(html)
 
 
 class PermissionsAPIHandler(APIHandler):


### PR DESCRIPTION
Fixes #190

## Changes

- [x] Pull from `quay.io/jupyterhub/repo2docker`
- [x] Pin to `jupyterhub~=1.5` for now
- [x] Update to `dockerspawner~=12.1`
- [x] Fix awaitable check introduced in a recent (1.3?) jupyterhub release  
- [x] Update docs build
- [x] Update to newer Python versions on CI