### PR TITLE
Add init to extra_host_config

### DIFF
--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -124,6 +124,10 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     # set the default cpu and memory limits
     c.PlasmaSpawner.args = ["--ResourceUseDisplay.track_cpu_percent=True"]
 
+    # prevent PID 1 running in the Docker container to stop when children processes are killed
+    # see https://github.com/plasmabio/plasma/issues/191 for more info
+    c.PlasmaSpawner.extra_host_config = {'init': True}
+
     # register Cockpit as a service if active
     if check_service_active("cockpit"):
         c.JupyterHub.services.append(

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -124,7 +124,7 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     # set the default cpu and memory limits
     c.PlasmaSpawner.args = ["--ResourceUseDisplay.track_cpu_percent=True"]
 
-    # prevent PID 1 running in the Docker container to stop when children processes are killed
+    # prevent PID 1 running in the Docker container to stop when child processes are killed
     # see https://github.com/plasmabio/plasma/issues/191 for more info
     c.PlasmaSpawner.extra_host_config = {'init': True}
 


### PR DESCRIPTION
This should fix https://github.com/plasmabio/plasma/issues/191

This new parameter corresponds to `--init` documented here: https://docs.docker.com/engine/reference/commandline/run/#options

![image](https://user-images.githubusercontent.com/591645/160571208-e0988578-12a9-46cf-b93b-a49434f88ee5.png)

This adds a new process as PID 1 in the Docker container:

![image](https://user-images.githubusercontent.com/591645/160571036-aa6b479a-bd3a-4b50-a247-8d0834c754c9.png)


- [ ] Add / update the documentation
