### PR TITLE
Pin `sqlalchemy<2`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
 git+https://github.com/plasmabio/tljh-repo2docker
-jupyterhub~=1.4.5
+jupyterhub~=1.4.2
 notebook<7
 pytest
 pytest-aiohttp

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
 git+https://github.com/plasmabio/tljh-repo2docker
-jupyterhub~=1.5
-notebook
+jupyterhub~=1.4.5
+notebook<7
 pytest
 pytest-aiohttp
 pytest-asyncio

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
 git+https://github.com/plasmabio/tljh-repo2docker
-jupyterhub~=1.4.2
+jupyterhub~=1.5
 notebook<7
 pytest
 pytest-aiohttp

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4.5", "sqlalchemy<2"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4.2", "sqlalchemy<2"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4.5", "sqlalchemy<2"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "jupyterhub~=1.4.2", "sqlalchemy<2"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "sqlalchemy<2"],
 )


### PR DESCRIPTION
Fixes https://github.com/plasmabio/plasma/issues/218.

Some transitive dependencies got newer major versions since the last time the repo was updated.