### PR TITLE
Minor CI maintenance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
-       node-version: '10.x'
+       node-version: '18.x'
     - name: Install configurable-http-proxy
       run: npm -g install configurable-http-proxy
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Minor CI maintenance to:

- [x] Bump GitHub actions
- [x] Bump to `nodejs` 18.x on CI
- [x] Bump to Python 3.10 on CI
