### PR TITLE
Update to TLJH 1.0, `tljh-repo2docker==1.0.2`, Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ ansible/*.csv
 
 # local TLJH config used for testing
 config.yaml
+hosts

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ ansible/*.csv
 
 # local TLJH config used for testing
 config.yaml
-hosts

--- a/ansible/cockpit.yml
+++ b/ansible/cockpit.yml
@@ -5,11 +5,11 @@
     - vars/default.yml
 
   tasks:
-    - name: Add eoan-backports repository to be able to install cockpit-docker
+    - name: Add noble-backports repository to be able to install cockpit-docker
       apt_repository:
-        repo: deb http://fr.archive.ubuntu.com/ubuntu eoan-backports main universe
+        repo: deb http://fr.archive.ubuntu.com/ubuntu noble-backports main universe
         state: present
-      when: ansible_distribution_release == 'focal'
+      when: ansible_distribution_release == 'noble'
 
     - name: Install Cockpit with the Docker plugin
       apt: name={{ item }} state=latest update_cache=yes

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -3,33 +3,150 @@
   become: true
 
   tasks:
-    - name: Install required system packages
-      apt: name={{ item }} state=latest update_cache=yes
-      loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools']
+    - name: Get Ubuntu codename
+      shell: lsb_release -cs
+      register: ubuntu_codename
+      changed_when: false
 
-    - name: Add Docker GPG apt Key
-      apt_key:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        state: present
-
-    - name: Add Docker Repository
-      apt_repository:
-        repo: deb https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
-        state: present
-
-    - name: Update apt and install docker-ce
-      apt: update_cache=yes name=docker-ce state=latest
-
-    - name: Install Docker Module for Python
-      pip:
+    - name: Stop Docker service if running
+      systemd:
         name: docker
+        state: stopped
+      ignore_errors: yes
+
+    - name: Remove all Docker packages to avoid conflicts
+      apt:
+        name: "{{ item }}"
+        state: absent
+        purge: yes
+      loop:
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+        - docker-buildx-plugin
+        - docker-compose-plugin
+        - docker.io
+        - docker-doc
+        - docker-compose
+        - podman-docker
+        - containerd
+        - runc
+      ignore_errors: yes
+
+    - name: Remove all existing Docker repository files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/docker.list
+        - /etc/apt/sources.list.d/docker-ce.list
+        - /etc/apt/sources.list.d/docker.sources
+        - /etc/apt/sources.list.d/archive_uri-https_download_docker_com_linux_ubuntu-jammy.list
+        - /etc/apt/sources.list.d/archive_uri-https_download_docker_com_linux_ubuntu-focal.list
+        - /etc/apt/sources.list.d/archive_uri-https_download_docker_com_linux_ubuntu-noble.list
+      ignore_errors: yes
+
+    - name: Remove Docker entries from main sources.list and sources.list.d
+      shell: |
+        sed -i '/download\.docker\.com/d' /etc/apt/sources.list
+        find /etc/apt/sources.list.d/ -name "*.list" -exec sed -i '/download\.docker\.com/d' {} \;
+      ignore_errors: yes
+
+    - name: Remove existing Docker GPG keys
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/keyrings/docker.gpg
+        - /usr/share/keyrings/docker-archive-keyring.gpg
+        - /etc/apt/trusted.gpg.d/docker.gpg
+      ignore_errors: yes
+
+    - name: Clean apt cache completely
+      shell: |
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+        apt-get update
+      ignore_errors: yes
+
+    - name: Install required system packages
+      apt:
+        name: "{{ item }}"
+        state: latest
+        update_cache: yes
+      loop:
+        - 'apt-transport-https'
+        - 'ca-certificates'
+        - 'curl'
+        - 'software-properties-common'
+        - 'python3-pip'
+        - 'virtualenv'
+        - 'python3-setuptools'
+        - 'gnupg'
+        - 'lsb-release'
+
+    - name: Create directory for Docker GPG key
+      file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: Download Docker GPG key
+      get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /tmp/docker.gpg
+        mode: '0644'
+
+    - name: Add Docker GPG key to keyring
+      shell: |
+        gpg --dearmor < /tmp/docker.gpg > /etc/apt/keyrings/docker.gpg
+        chmod a+r /etc/apt/keyrings/docker.gpg
+      args:
+        creates: /etc/apt/keyrings/docker.gpg
+
+    - name: Add Docker Repository with proper signing
+      apt_repository:
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ubuntu_codename.stdout }} stable"
+        state: present
+        filename: docker
+
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install Docker packages
+      apt:
+        name: "{{ item }}"
+        state: latest
+      loop:
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+        - docker-buildx-plugin
+        - docker-compose-plugin
 
     - name: Enable the journald logging driver
       copy:
         src: daemon.json
         dest: /etc/docker/daemon.json
+      notify: restart docker
 
-    - name: Reload Docker
+    - name: Start and enable Docker service
+      systemd:
+        name: docker
+        state: started
+        enabled: yes
+        daemon_reload: yes
+
+    - name: Add current user to docker group (if not root)
+      user:
+        name: "{{ ansible_user }}"
+        groups: docker
+        append: yes
+      when: ansible_user != "root"
+
+  handlers:
+    - name: restart docker
       systemd:
         name: docker
         state: restarted

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -27,8 +27,15 @@
     - name: Run the TLJH installer
       shell: |
         {{ ansible_python_interpreter }} {{ tljh_installer_dest }} \
+          --version {{ tljh_version }} \
           --plugin {{ tljh_plasma }} {{ tljh_repo2docker }}
-          --version {{ tljh_version }}
+
+    # Wait for initial setup to complete
+    - name: Wait for JupyterHub to be ready after installation
+      wait_for:
+        port: 80
+        delay: 10
+        timeout: 300
 
     - name: Set the idle culler timeout to 1 hour
       shell: "tljh-config set services.cull.timeout 3600"
@@ -38,8 +45,58 @@
         tljh-config set limits.memory 2G
         tljh-config set limits.cpu 2
 
-    - name: Reload the hub
-      shell: "tljh-config reload hub"
+    # Validate configuration before reloading
+    - name: Validate TLJH configuration
+      shell: "tljh-config show"
+      register: config_validation
+
+    - name: Stop JupyterHub service gracefully before reload
+      shell: "systemctl stop jupyterhub.service"
+      ignore_errors: yes
+
+    # Wait a moment for the service to stop
+    - name: Wait for service to stop
+      wait_for:
+        port: 80
+        state: stopped
+        timeout: 30
+      ignore_errors: yes
+
+    - name: Check for any remaining JupyterHub processes
+      shell: "pkill -f jupyterhub || true"
+      ignore_errors: yes
+
+    - name: Start JupyterHub service
+      shell: "systemctl start jupyterhub.service"
+      register: start_result
+      ignore_errors: yes
+
+    - name: Wait for JupyterHub to start
+      wait_for:
+        port: 80
+        delay: 5
+        timeout: 60
+      when: start_result.rc == 0
+
+    - name: Check JupyterHub service status
+      shell: "systemctl status jupyterhub.service"
+      register: final_status
+      ignore_errors: yes
+
+    - name: Show JupyterHub logs if service failed
+      shell: "journalctl -xeu jupyterhub.service --no-pager -n 100"
+      register: service_logs
+      when: start_result.rc != 0
+
+    - name: Display service logs if startup failed
+      debug:
+        msg: "{{ service_logs.stdout }}"
+      when: start_result.rc != 0
+
+    - name: Fail if JupyterHub couldn't start
+      fail:
+        msg: "JupyterHub service failed to start. Check the logs above."
+      when: start_result.rc != 0
 
     # Pull the repo2docker image to build user images
     - name: Pull the repo2docker Docker image

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -26,11 +26,8 @@
 
     - name: Run the TLJH installer
       shell: |
-        {{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env \
+        {{ ansible_python_interpreter }} {{ tljh_installer_dest }} \
           --plugin {{ tljh_plasma }} {{ tljh_repo2docker }}
-      # TODO: remove when --no-user-env (or equivalent) is available
-      environment:
-        TLJH_BOOTSTRAP_PIP_SPEC: "{{ tljh_bootstrap_pip_spec }}"
 
     - name: Set the idle culler timeout to 1 hour
       shell: "tljh-config set services.cull.timeout 3600"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -28,6 +28,7 @@
       shell: |
         {{ ansible_python_interpreter }} {{ tljh_installer_dest }} \
           --plugin {{ tljh_plasma }} {{ tljh_repo2docker }}
+          --version {{ tljh_version }}
 
     - name: Set the idle culler timeout to 1 hour
       shell: "tljh-config set services.cull.timeout 3600"

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -5,5 +5,6 @@ tljh_repo2docker: tljh-repo2docker==1.0.2
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
 tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
+tljh_version: 1.0.0
 
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -1,6 +1,6 @@
 ---
 
-tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
+tljh_plasma: git+https://github.com/jtpio/plasma@updates#"egg=tljh-plasma&subdirectory=tljh-plasma"
 tljh_repo2docker: tljh-repo2docker==1.0.2
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -1,7 +1,7 @@
 ---
 
 tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
-tljh_repo2docker: tljh-repo2docker==1.0.1
+tljh_repo2docker: tljh-repo2docker==1.0.2
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
 # TODO: update to upstream TLJH links when the --no-user-env (or similar) is available

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -4,9 +4,6 @@ tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&sub
 tljh_repo2docker: tljh-repo2docker==1.0.2
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
-# TODO: update to upstream TLJH links when the --no-user-env (or similar) is available
-# See https://github.com/jupyterhub/the-littlest-jupyterhub/pull/528
-tljh_bootstrap_pip_spec: git+https://github.com/jtpio/the-littlest-jupyterhub.git@skip-install#"egg=the_littlest_jupyterhub"
-tljh_installer_url: https://raw.githubusercontent.com/jtpio/the-littlest-jupyterhub/skip-install/bootstrap/bootstrap.py
+tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
 
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -1,6 +1,6 @@
 ---
 
-tljh_plasma: git+https://github.com/jtpio/plasma@updates#"egg=tljh-plasma&subdirectory=tljh-plasma"
+tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
 tljh_repo2docker: tljh-repo2docker==1.0.2
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ pytest-asyncio
 pytest-cov
 pytest-jupyterhub
 requests-mock
+passlib

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
-tljh-repo2docker<2
+tljh-repo2docker>=1.0.2,<2
 jupyterhub~=1.5
 notebook<7
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,10 @@
-git+https://github.com/jupyterhub/the-littlest-jupyterhub
+git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
 tljh-repo2docker>=1.0.2,<2
-jupyterhub~=1.5
-notebook<7
+jupyterhub>=4,<5
+notebook
 pytest
 pytest-aiohttp
 pytest-asyncio
 pytest-cov
+pytest-jupyterhub
 requests-mock

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Based on the Jupyter ecosystem, Plasma allows the creation and the management of
 with an easy deployement on bare-metal servers or virtual machines.
 
 Plasma utilizes [tljh-repo2docker](https://github.com/plasmabio/tljh-repo2docker),
-a [repo2docker](https://github.com/jupyterhub/repo2docker) plugin for [The Littlest JupyterHub](https://tljh.jupyter.org/en/latest/).
+a [repo2docker](https://github.com/jupyterhub/repo2docker) plugin for [The Littlest JupyterHub](https://tljh.jupyter.org/en/latest/) 1.0.
 
 For more details, have a look at:
 

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -4,7 +4,7 @@
 
 Before installing Plasma, you will need:
 
-- A server running at least **Ubuntu 18.04**
+- A server running **Ubuntu 24.04**
 - The public IP of the server
 - SSH access to the machine
 - A `priviledged user` on the remote machine that can issue commands using `sudo`
@@ -32,7 +32,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCeeTSTvuZ4KzWBwUj2yIKNhX9Jw+LLdNfjOaVONfnY
 
 It can then be manually added to `~/.ssh/authorized_keys` on the server.
 
-For more information, checkout [this tutorial on DigitalOcean to set up SSH Keys on Ubuntu 18.04](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on-ubuntu-1804).
+For more information, checkout [this tutorial on DigitalOcean to set up SSH Keys on Ubuntu 18.04](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on-ubuntu-1804), which should be similar for Ubuntu 24.04.
 
 (requirements-server)=
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-Plasma is built with [The Littlest JupyterHub](https://the-littlest-jupyterhub.readthedocs.io/en/latest/) (TLJH)
+Plasma is built with [The Littlest JupyterHub](https://the-littlest-jupyterhub.readthedocs.io/en/latest/) (TLJH) 1.0
 and uses Docker containers to start the user servers.
 
 The project provides:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = test_*.py
+asyncio_mode = auto

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "sqlalchemy<2"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker>=1.0.2,<2", "sqlalchemy<2"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=13.0", "tljh_repo2docker>=1.0.2,<2", "sqlalchemy<2"],
+    install_requires=["dockerspawner~=12.1", "tljh_repo2docker>=1.0.2,<2", "sqlalchemy<2"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker>=1.0.2,<2", "sqlalchemy<2"],
+    install_requires=["dockerspawner~=13.0", "tljh_repo2docker>=1.0.2,<2", "sqlalchemy<2"],
 )

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -123,6 +123,8 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     c.PlasmaSpawner.cmd = ["/srv/conda/envs/notebook/bin/jupyterhub-singleuser"]
     # set the default cpu and memory limits
     c.PlasmaSpawner.args = ["--ResourceUseDisplay.track_cpu_percent=True"]
+    # explicitely opt-in to enable the custom entrypoint logic
+    c.PlasmaSpawner.run_as_root = True
 
     # prevent PID 1 running in the Docker container to stop when child processes are killed
     # see https://github.com/plasmabio/plasma/issues/191 for more info

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -126,6 +126,9 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     # explicitely opt-in to enable the custom entrypoint logic
     c.PlasmaSpawner.run_as_root = True
 
+    # Since dockerspawner 13
+    c.DockerSpawner.allowed_images = "*"
+
     # prevent PID 1 running in the Docker container to stop when child processes are killed
     # see https://github.com/plasmabio/plasma/issues/191 for more info
     c.PlasmaSpawner.extra_host_config = {'init': True}

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -120,7 +120,7 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     c.PlasmaSpawner.remove = True
     c.PlasmaSpawner.default_url = "/lab"
     # TODO: change back to jupyterhub-singleuser
-    c.PlasmaSpawner.cmd = ["/srv/conda/envs/notebook/bin/jupyterhub-singleuser"]
+    c.PlasmaSpawner.cmd = ["jupyterhub-singleuser"]
     # set the default cpu and memory limits
     c.PlasmaSpawner.args = ["--ResourceUseDisplay.track_cpu_percent=True"]
     # explicitely opt-in to enable the custom entrypoint logic

--- a/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
+++ b/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
@@ -43,4 +43,4 @@ export JUPYTER_PATH=${IMAGE_DIR}/.local/share/jupyter
 cd ${IMAGE_DIR}
 
 # execute the notebook process as the given user
-exec su $NB_USER -m -c '"$0" "$@"' -- "$@"
+exec su - $NB_USER -m -c '"$0" "$@"' -- "$@"

--- a/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
+++ b/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
@@ -43,4 +43,4 @@ export JUPYTER_PATH=${IMAGE_DIR}/.local/share/jupyter
 cd ${IMAGE_DIR}
 
 # execute the notebook process as the given user
-exec su - $NB_USER -m -c '"$0" "$@"' -- "$@"
+exec su $NB_USER -m -c '"$0" "$@"' -- "$@"

--- a/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
+++ b/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
@@ -31,6 +31,11 @@ TOPBAR_TEXT_SETTINGS_DIR=${IMAGE_DIR}/.jupyter/lab/user-settings/jupyterlab-topb
 mkdir -p ${TOPBAR_TEXT_SETTINGS_DIR}
 echo "{\"editable\": false, \"text\":\"${USER_IMAGE}\"}" > ${TOPBAR_TEXT_SETTINGS_DIR}/plugin.jupyterlab-settings
 
+# enable the resource usage indicators in the topbar
+RESOURCE_USAGE_SETTINGS_DIR=${IMAGE_DIR}/.jupyter/lab/user-settings/@jupyter-server/resource-usage
+mkdir -p ${RESOURCE_USAGE_SETTINGS_DIR}
+echo "{\"enabled\": true}" > ${RESOURCE_USAGE_SETTINGS_DIR}/topbar-item.jupyterlab-settings
+
 # set the correct permissions for the user home subdirectory
 chown -R ${NB_USER}:${NB_USER} ${IMAGE_DIR}
 

--- a/tljh-plasma/tljh_plasma/permissions.py
+++ b/tljh-plasma/tljh_plasma/permissions.py
@@ -7,7 +7,7 @@ from inspect import isawaitable
 from jupyterhub.apihandlers import APIHandler
 from jupyterhub.handlers.base import BaseHandler
 from jupyterhub.orm import Base, Column, Integer, Unicode
-from jupyterhub.utils import admin_only
+from jupyterhub.scopes import needs_scope
 from tljh_repo2docker.docker import list_images
 from tornado.web import authenticated
 
@@ -32,7 +32,7 @@ class PermissionsHandler(BaseHandler):
     """
 
     @authenticated
-    @admin_only
+    @needs_scope("admin-ui")
     async def get(self):
         include_groups = self.settings.get("include_groups")
         all_groups = list_groups(include_groups)
@@ -60,8 +60,8 @@ class PermissionsAPIHandler(APIHandler):
     Handle edits to the mapping of environments and groups.
     """
 
-    @admin_only
     @authenticated
+    @needs_scope("admin-ui")
     async def post(self):
         raw_args = self.request.body.decode("utf-8")
         args = json.loads(raw_args)

--- a/tljh-plasma/tljh_plasma/tests/conftest.py
+++ b/tljh-plasma/tljh_plasma/tests/conftest.py
@@ -1,16 +1,12 @@
-import asyncio
-import os
-import sys
-
 import pytest
 
+from jupyterhub.tests.mocking import MockPAMAuthenticator
 from tljh_repo2docker.tests.conftest import (
     minimal_repo,
     image_name,
     generated_image_name,
     remove_all_test_images
 )
-from tljh_repo2docker.tests.utils import add_environment
 from tljh_repo2docker import tljh_custom_jupyterhub_config as tljh_repo2docker_config
 from tljh_plasma import tljh_custom_jupyterhub_config as tljh_plasma_config
 from traitlets.config import Config
@@ -19,10 +15,11 @@ from traitlets.config import Config
 @pytest.fixture
 async def app(hub_app):
     config = Config()
-    config.authenticator_class = 'jupyterhub.tests.mocking.MockPAMAuthenticator'
 
     tljh_repo2docker_config(config)
     tljh_plasma_config(config)
+
+    config.JupyterHub.authenticator_class = MockPAMAuthenticator
 
     app = await hub_app(config=config)
     return app

--- a/tljh-plasma/tljh_plasma/tests/conftest.py
+++ b/tljh-plasma/tljh_plasma/tests/conftest.py
@@ -1,17 +1,10 @@
 import asyncio
+import os
 import sys
 
 import pytest
 
-from jupyterhub.tests.conftest import (
-    io_loop,
-    event_loop,
-    db,
-    pytest_collection_modifyitems,
-)
-from jupyterhub.tests.mocking import MockHub, MockPAMAuthenticator
 from tljh_repo2docker.tests.conftest import (
-    DummyConfig,
     minimal_repo,
     image_name,
     generated_image_name,
@@ -20,40 +13,16 @@ from tljh_repo2docker.tests.conftest import (
 from tljh_repo2docker.tests.utils import add_environment
 from tljh_repo2docker import tljh_custom_jupyterhub_config as tljh_repo2docker_config
 from tljh_plasma import tljh_custom_jupyterhub_config as tljh_plasma_config
+from traitlets.config import Config
 
 
-@pytest.fixture(scope="module")
-def app(request, io_loop):
-    """
-    Adapted from:
-    https://github.com/jupyterhub/jupyterhub/blob/8a3790b01ff944c453ffcc0486149e2a58ffabea/jupyterhub/tests/conftest.py#L74
-    """
+@pytest.fixture
+async def app(hub_app):
+    config = Config()
+    config.authenticator_class = 'jupyterhub.tests.mocking.MockPAMAuthenticator'
 
-    # create a JupyterHub mock instance
-    mocked_app = MockHub.instance()
-    c = DummyConfig()
-    c.JupyterHub = mocked_app
+    tljh_repo2docker_config(config)
+    tljh_plasma_config(config)
 
-    # apply the config from the plugins
-    tljh_repo2docker_config(c)
-    tljh_plasma_config(c)
-
-    # switch back to the MockPAMAuthenticator for the tests
-    c.JupyterHub.authenticator_class = MockPAMAuthenticator
-
-    async def make_app():
-        await mocked_app.initialize([])
-        await mocked_app.start()
-
-    def fin():
-        # disconnect logging during cleanup because pytest closes captured FDs prematurely
-        mocked_app.log.handlers = []
-        MockHub.clear_instance()
-        try:
-            mocked_app.stop()
-        except Exception as e:
-            print("Error stopping Hub: %s" % e, file=sys.stderr)
-
-    request.addfinalizer(fin)
-    io_loop.run_sync(make_app)
-    return mocked_app
+    app = await hub_app(config=config)
+    return app


### PR DESCRIPTION
Trying to perform a more minimal update than https://github.com/plasmabio/plasma/pull/224, as https://github.com/plasmabio/plasma/pull/224 requires more work to be fully working.

Fixes https://github.com/plasmabio/plasma/issues/227

> [!NOTE]
> The most relevant change from this update to fix #227 is the bump to `tljh-repo2docker==1.0.2` which includes https://github.com/plasmabio/tljh-repo2docker/pull/103.
> But since `tljh-repo2docker==1.0.2` also updated to JupyterHub 4, this PR updates to TLJH 1.0 (based on JupyterHub 4)

Testing with https://github.com/plasmabio/template-python/pull/13 which updates to JupyterHub 4

- [x] Update to a pinned version of the TLJH installer (v1): https://tljh.jupyter.org/en/latest/howto/admin/upgrade-tljh.html#step-3-make-the-upgrade
- [x] Update to JupyterHub 4
- [x] Use `pytest-jupyterhub` for the tests
- [x] Drop Python 3.8 in the tests
- [x] Update playbooks to new ubuntu and docker
- [x] Document new requirements:
  - [x] Ubuntu 24.04
  - [x] TLJH 1.0
